### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -15,7 +15,7 @@
     },
     "repo-type"     : "git",
     "source-url"    : "git://github.com/niner/Grammar-Highlighter.git",
-    "license"       : "http://www.perlfoundation.org/artistic_license_2_0",
+    "license"       : "Artistic-2.0",
     "support"       : {
         "irc" : "irc://irc.freenode.org/#perl6"
     }


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license